### PR TITLE
Add initial unit tests and CI pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: File a bug report
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charm. If not, please switch to this image prior to 
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to help explain your problem. If applicable, add screenshots to 
+        help explain the problem you are facing.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behavior.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
+        at https://juju.is/docs/olm/juju-logs
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,8 +6,8 @@ body:
     attributes:
       value: >
         Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
-        sure you are using the latest version of the charm. If not, please switch to this image prior to 
-        posting your report to make sure it's not already solved.
+        sure you are using the latest version of the charm. If not, please switch to the lastest version of this charm
+        before posting your report to make sure it's not already solved.
   - type: textarea
     id: bug-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,8 +13,7 @@ body:
     attributes:
       label: Bug Description
       description: >
-        If applicable, add screenshots to help explain your problem. If applicable, add screenshots to 
-        help explain the problem you are facing.
+        Provide a description of the issue you are facing. If applicable, add screenshots to help explain the problem.
     validations:
       required: true
   - type: textarea
@@ -46,7 +45,7 @@ body:
       label: Relevant log output
       description: >
         Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
+        Fetch the logs using `juju debug-log --replay`. Additional details available in the juju docs 
         at https://juju.is/docs/olm/juju-logs
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,0 +1,17 @@
+name: Enhancement Proposal
+description: File an enhancement proposal
+labels: ["Type: Enhancement", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
+        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+  - type: textarea
+    id: enhancement-proposal
+    attributes:
+      label: Enhancement Proposal
+      description: >
+        Describe the enhancement you would like to see in as much detail as needed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -5,8 +5,8 @@ body:
   - type: markdown
     attributes:
       value: >
-        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
-        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+        Thanks for taking the time to fill out this enhancement proposal! Before submitting your proposal, please make
+        sure there isn't a pre-existing similar proposal. If there is, please join that discussion instead.
   - type: textarea
     id: enhancement-proposal
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,10 @@ motivation and context. Is it a new feature? A bug fix? Does it address an exist
 ## How was the code tested?
 
 > Describe the conditions under which the code has been tested.
+> * Did you run the defined integration and units under `tests/`?
+> * Did you write new tests? Where are they located in the repository?
+> * Which undercloud did you use to perform the tests? LXD, vSphere, AWS, etc.
+> * What operating system did you test the charms on? Ubuntu 22.04, Ubuntu 20.04, CentOS 7, etc.
 
 ## Related issues and/or tasks
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+> Provide a description of the purpose of this pull request, as well as its
+motivation and context. Is it a new feature? A bug fix? Does it address an existing issue?
+
+## How was the code tested?
+
+> Describe the conditions under which the code has been tested.
+
+## Related issues and/or tasks
+
+> Link any related issues or project board tasks to this pull request.
+
+## Checklist
+
+- [ ] I am the author of these changes, or I have the rights to submit them.
+- [ ] I have added the relevant changes to the README and/or documentation.
+- [ ] I have self reviewed my own code.
+- [ ] All requested changes and/or review comments have been resolved.

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -4,6 +4,19 @@ on:
   workflow_call:
 
 jobs:
+  inclusive-naming-check:
+    name: Inclusive naming
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -25,16 +38,3 @@ jobs:
         run: python3 -m pip install tox
       - name: Run tests
         run: tox -e unit
-
-  call-inclusive-naming-check:
-    name: Inclusive naming
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: woke
-        uses: get-woke/woke-action@v0
-        with:
-          # Cause the check to fail on any broke rules
-          fail-on-error: true

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -25,3 +25,16 @@ jobs:
         run: python3 -m pip install tox
       - name: Run tests
         run: tox -e unit
+
+  call-inclusive-naming-check:
+    name: Inclusive naming
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,27 @@
+name: Build/Test
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run tests
+        run: tox -e unit

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,9 @@
+name: Tests
+on:
+  pull_request:
+    paths-ignore:
+      - ".gitignore"
+
+jobs:
+  test:
+    uses: ./.github/workflows/build-and-test.yaml

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Canonical Ltd.
+   Copyright 2023 Canonical Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Canonical Ltd.
+   Copyright 2023 Omnivector, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,20 +14,26 @@ log_cli_level = "INFO"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Testing tools configuration
 [tool.coverage.run]
 branch = true

--- a/src/interface_slurmrestd.py
+++ b/src/interface_slurmrestd.py
@@ -3,7 +3,6 @@
 import json
 import logging
 
-
 from ops.framework import (
     EventBase,
     EventSource,
@@ -11,7 +10,6 @@ from ops.framework import (
     ObjectEvents,
     StoredState,
 )
-
 
 logger = logging.getLogger()
 
@@ -62,21 +60,18 @@ class SlurmrestdRequires(Object):
         self._stored.set_default(
             munge_key=str(),
             jwt_rsa=str(),
-            slurm_config=dict(),
+            slurm_config={},
             restart_slurmrestd_uuid=str(),
         )
 
         self.framework.observe(
-            self._charm.on[relation_name].relation_joined,
-            self._on_relation_joined
+            self._charm.on[relation_name].relation_joined, self._on_relation_joined
         )
         self.framework.observe(
-            self._charm.on[relation_name].relation_changed,
-            self._on_relation_changed
+            self._charm.on[relation_name].relation_changed, self._on_relation_changed
         )
         self.framework.observe(
-            self._charm.on[relation_name].relation_broken,
-            self._on_relation_broken
+            self._charm.on[relation_name].relation_broken, self._on_relation_broken
         )
 
     def _on_relation_joined(self, event):
@@ -119,8 +114,8 @@ class SlurmrestdRequires(Object):
 
         logger.debug("## slurmrestd - relation changed")
 
-        munge_key = event_app_data.get('munge_key')
-        jwt_rsa = event_app_data.get('jwt_rsa')
+        munge_key = event_app_data.get("munge_key")
+        jwt_rsa = event_app_data.get("jwt_rsa")
         restart_slurmrestd_uuid = event_app_data.get("restart_slurmrestd_uuid")
         slurm_config = self._get_slurm_config_from_relation()
 
@@ -162,7 +157,7 @@ class SlurmrestdRequires(Object):
             if app:
                 app_data = self._relation.data.get(app)
                 if app_data:
-                    slurm_config = app_data.get('slurm_config')
+                    slurm_config = app_data.get("slurm_config")
                     if slurm_config:
                         return json.loads(slurm_config)
         return {}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -18,9 +18,18 @@ class TestCharm(unittest.TestCase):
         defer.assert_called()
 
     @patch("slurm_ops_manager.SlurmManager.render_slurm_configs")
-    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", return_value={"cluster_name": "test"})
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
-    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch(
+        "interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config",
+        return_value={"cluster_name": "test"},
+    )
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot",
+        new_callable=PropertyMock(return_value=False),
+    )
+    @patch(
+        "interface_slurmrestd.SlurmrestdRequires.is_joined",
+        new_callable=PropertyMock(return_value=True),
+    )
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
@@ -43,8 +52,14 @@ class TestCharm(unittest.TestCase):
         self.assertFalse(self.harness.charm._stored.slurm_installed)
         defer.assert_called()
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
-    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot",
+        new_callable=PropertyMock(return_value=False),
+    )
+    @patch(
+        "interface_slurmrestd.SlurmrestdRequires.is_joined",
+        new_callable=PropertyMock(return_value=True),
+    )
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
@@ -76,7 +91,7 @@ class TestCharm(unittest.TestCase):
     def test_munge_key_available_fail(self, defer):
         self.harness.charm._slurmrestd.on.munge_key_available.emit()
         defer.assert_called()
-    
+
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key")
     @patch("slurm_ops_manager.SlurmManager.configure_munge_key")
     @patch("slurm_ops_manager.SlurmManager.restart_munged")
@@ -93,15 +108,21 @@ class TestCharm(unittest.TestCase):
         defer.assert_called()
 
     @patch("slurm_ops_manager.SlurmManager.restart_slurm_component", lambda _: True)
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
-    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot",
+        new_callable=PropertyMock(return_value=False),
+    )
+    @patch(
+        "interface_slurmrestd.SlurmrestdRequires.is_joined",
+        new_callable=PropertyMock(return_value=True),
+    )
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
     @patch("ops.framework.EventBase.defer")
     def test_restart_slurmrestd_success(self, defer, *_):
         self.harness.charm._stored.slurm_installed = True
-        
+
         self.harness.charm._slurmrestd.on.restart_slurmrestd.emit()
         self.assertTrue(self.harness.charm._stored.slurmrestd_restarted)
         defer.assert_not_called()
@@ -112,10 +133,18 @@ class TestCharm(unittest.TestCase):
 
     def test_update_status_fail(self):
         self.harness.charm.on.update_status.emit()
-        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Error installing slurmrestd"))
+        self.assertEqual(
+            self.harness.charm.unit.status, BlockedStatus("Error installing slurmrestd")
+        )
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
-    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot",
+        new_callable=PropertyMock(return_value=False),
+    )
+    @patch(
+        "interface_slurmrestd.SlurmrestdRequires.is_joined",
+        new_callable=PropertyMock(return_value=True),
+    )
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
@@ -128,11 +157,19 @@ class TestCharm(unittest.TestCase):
     @patch("pathlib.Path.read_text", return_value="v1.0.0")
     def test_upgrade_fail(self, *_):
         self.harness.charm.on.upgrade_charm.emit()
-        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Error installing slurmrestd"))
+        self.assertEqual(
+            self.harness.charm.unit.status, BlockedStatus("Error installing slurmrestd")
+        )
 
     @patch("pathlib.Path.read_text", return_value="v1.0.0")
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
-    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot",
+        new_callable=PropertyMock(return_value=False),
+    )
+    @patch(
+        "interface_slurmrestd.SlurmrestdRequires.is_joined",
+        new_callable=PropertyMock(return_value=True),
+    )
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
     @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,19 +2,117 @@ import unittest
 from unittest.mock import PropertyMock, patch
 
 from charm import SlurmrestdCharm
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
+
 
 class TestCharm(unittest.TestCase):
     def setUp(self) -> None:
         self.harness = Harness(SlurmrestdCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
-        self.maxDiff = None
+
+    @patch("ops.framework.EventBase.defer")
+    def test_config_available_fail(self, defer):
+        self.harness.charm._slurmrestd.on.config_available.emit()
+        defer.assert_called()
+
+    @patch("slurm_ops_manager.SlurmManager.render_slurm_configs")
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", return_value={"cluster_name": "test"})
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
+    @patch("ops.framework.EventBase.defer")
+    def test_config_available_success(self, defer, *_):
+        self.harness.charm._stored.slurm_installed = True
+        self.harness.charm._stored.slurmrestd_restarted = True
+
+        self.harness.charm._slurmrestd.on.config_available.emit()
+        defer.assert_not_called()
+
+    def test_config_unavailable(self):
+        self.harness.charm._slurmrestd.on.config_unavailable.emit()
+        self.assertFalse(self.harness.charm._stored.slurmrestd_restarted)
+
+    @patch("pathlib.Path.read_text", return_value="v1.0.0")
+    @patch("ops.framework.EventBase.defer")
+    def test_install_fail(self, defer, *_):
+        self.harness.charm.on.install.emit()
+        self.assertFalse(self.harness.charm._stored.slurm_installed)
+        defer.assert_called()
+
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
+    @patch("slurm_ops_manager.SlurmManager.install")
+    @patch("pathlib.Path.read_text", return_value="v1.0.0")
+    @patch("slurm_ops_manager.SlurmManager.start_munged", lambda _: True)
+    @patch("ops.framework.EventBase.defer")
+    def test_install_success(self, defer, *_):
+        self.harness.charm.on.install.emit()
+        self.assertTrue(self.harness.charm._stored.slurm_installed)
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus("slurmrestd available"))
+        defer.assert_not_called()
+
+    @patch("ops.framework.EventBase.defer")
+    def test_jwt_rsa_available_fail(self, defer):
+        self.harness.charm._slurmrestd.on.jwt_rsa_available.emit()
+        defer.assert_called()
+
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa")
+    @patch("slurm_ops_manager.SlurmManager.configure_jwt_rsa")
+    @patch("ops.framework.EventBase.defer")
+    def test_jwt_rsa_available_success(self, defer, *_):
+        self.harness.charm._stored.slurm_installed = True
+
+        self.harness.charm._slurmrestd.on.jwt_rsa_available.emit()
+        defer.assert_not_called()
+
+    @patch("ops.framework.EventBase.defer")
+    def test_munge_key_available_fail(self, defer):
+        self.harness.charm._slurmrestd.on.munge_key_available.emit()
+        defer.assert_called()
+    
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key")
+    @patch("slurm_ops_manager.SlurmManager.configure_munge_key")
+    @patch("slurm_ops_manager.SlurmManager.restart_munged")
+    @patch("ops.framework.EventBase.defer")
+    def test_munge_key_available_success(self, defer, *_):
+        self.harness.charm._stored.slurm_installed = True
+
+        self.harness.charm._slurmrestd.on.munge_key_available.emit()
+        defer.assert_not_called()
+
+    @patch("ops.framework.EventBase.defer")
+    def test_restart_slurmrestd_fail(self, defer):
+        self.harness.charm._slurmrestd.on.restart_slurmrestd.emit()
+        defer.assert_called()
+
+    @patch("slurm_ops_manager.SlurmManager.restart_slurm_component", lambda _: True)
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
+    @patch("ops.framework.EventBase.defer")
+    def test_restart_slurmrestd_success(self, defer, *_):
+        self.harness.charm._stored.slurm_installed = True
+        
+        self.harness.charm._slurmrestd.on.restart_slurmrestd.emit()
+        self.assertTrue(self.harness.charm._stored.slurmrestd_restarted)
+        defer.assert_not_called()
+
+    def test_start(self):
+        self.harness.charm.on.start.emit()
+        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus(""))
 
     def test_update_status_fail(self):
         self.harness.charm.on.update_status.emit()
-        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Error installing slurmrestd"))
 
     @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
     @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
@@ -25,4 +123,21 @@ class TestCharm(unittest.TestCase):
         self.harness.charm._stored.slurm_installed = True
 
         self.harness.charm.on.update_status.emit()
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus("slurmrestd available"))
+
+    @patch("pathlib.Path.read_text", return_value="v1.0.0")
+    def test_upgrade_fail(self, *_):
+        self.harness.charm.on.upgrade_charm.emit()
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Error installing slurmrestd"))
+
+    @patch("pathlib.Path.read_text", return_value="v1.0.0")
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
+    def test_upgrade_success(self, *_):
+        self.harness.charm._stored.slurm_installed = True
+
+        self.harness.charm.on.upgrade_charm.emit()
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus("slurmrestd available"))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import PropertyMock, patch
+
+from charm import SlurmrestdCharm
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+class TestCharm(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = Harness(SlurmrestdCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.maxDiff = None
+
+    def test_update_status_fail(self):
+        self.harness.charm.on.update_status.emit()
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
+
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch("interface_slurmrestd.SlurmrestdRequires.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_munge_key", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_jwt_rsa", lambda _: True)
+    @patch("interface_slurmrestd.SlurmrestdRequires.get_stored_slurm_config", lambda _: True)
+    def test_update_status_success(self, *_):
+        self.harness.charm._stored.slurm_installed = True
+
+        self.harness.charm.on.update_status.emit()
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus("slurmrestd available"))

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,7 @@ envlist = lint, unit
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-lib_path = {toxinidir}/lib/charms/slurmrestd
-all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path} 
+all_path = {[vars]src_path} {[vars]tst_path}
 lxd_name = slurmrestd-func-test
 ftest_path = {toxinidir}/tests/functional
 
@@ -40,8 +39,6 @@ deps =
     codespell==2.2.2
     ruff==0.0.206
 commands =
-    # uncomment the following line if this charm owns a lib
-    codespell {[vars]lib_path}
     codespell {toxinidir}/. \
     --skip {toxinidir}/.git \
     --skip {toxinidir}/.tox \
@@ -70,58 +67,3 @@ commands =
         -s \
         {posargs}
     coverage report
-
-[testenv:functional]
-description = Build a LXD container for functional tests then run the tests
-allowlist_externals = 
-    lxc
-    bash
-commands =
-    # Create a LXC container with the relevant packages installed
-    bash -c 'lxc launch -qe ubuntu:jammy {[vars]lxd_name} -c=user.user-data="$(<{[vars]ftest_path}/test_setup.yaml)"'
-    # Wait for the cloud-init process to finish
-    lxc exec {[vars]lxd_name} -- bash -c "cloud-init status -w >/dev/null 2>&1"
-    # Copy all the files needed for integration testing
-    lxc file push -qp {toxinidir}/tox.ini {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qp {toxinidir}/pyproject.toml {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qp {toxinidir}/config.yaml {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qpr {toxinidir}/lib {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qpr {toxinidir}/src {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qpr {[vars]tst_path} {[vars]lxd_name}/{[vars]lxd_name}/
-    # Run the tests
-    lxc exec {[vars]lxd_name} -- tox -c /{[vars]lxd_name}/tox.ini -e functional-tests {posargs}
-commands_post =
-    -lxc stop {[vars]lxd_name}
-
-[testenv:functional-tests]
-description = Run functional tests
-deps =
-    ops==1.5.4
-    pytest==7.2.0
-commands =
-    pytest -v \
-           -s \
-           --tb native \
-           --ignore={[vars]tst_path}unit \
-           --ignore={[vars]tst_path}integration \
-           --log-cli-level=INFO \
-           {posargs}
-
-[testenv:integration]
-description = Run integration tests
-deps =
-    pytest==7.2.0
-    juju==3.0.4
-    pytest-operator==0.22.0
-    requests==2.28.1
-    tenacity==8.1.0
-commands =
-    pytest -v \
-           -s \
-           --tb native \
-           --ignore={[vars]tst_path}unit \
-           --ignore={[vars]tst_path}functional \
-           --log-cli-level=INFO
-           --model controller \
-           --keep-models \
-           {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,15 @@ envlist = lint, unit
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
-all_path = {[vars]src_path} {[vars]tst_path} 
+lib_path = {toxinidir}/lib/charms/slurmrestd
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path} 
+lxd_name = slurmrestd-func-test
+ftest_path = {toxinidir}/tests/functional
 
 [testenv]
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=pdb.set_trace
+  PYTHONBREAKPOINT=ipdb.set_trace
   PY_COLORS=1
 passenv =
   PYTHONPATH
@@ -25,50 +27,101 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    black
-    isort
+    black==22.12.0
+    ruff==0.0.206
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
-    flake8-docstrings
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
-    codespell
+    black==22.12.0
+    codespell==2.2.2
+    ruff==0.0.206
 commands =
     # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    codespell {[vars]lib_path}
+    codespell {toxinidir}/. \
+    --skip {toxinidir}/.git \
+    --skip {toxinidir}/.tox \
+    --skip {toxinidir}/build \
+    --skip {toxinidir}/lib \
+    --skip {toxinidir}/venv \
+    --skip {toxinidir}/.mypy_cache \
+    --skip {toxinidir}/icon.svg
+
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests
 deps =
-    pytest
-    coverage[toml]
+    pytest==7.2.0
+    coverage[toml]==6.5.0
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+        -m pytest \
+        --ignore={[vars]tst_path}integration \
+        --ignore={[vars]tst_path}functional \
+        --tb native \
+        -v \
+        -s \
+        {posargs}
     coverage report
+
+[testenv:functional]
+description = Build a LXD container for functional tests then run the tests
+allowlist_externals = 
+    lxc
+    bash
+commands =
+    # Create a LXC container with the relevant packages installed
+    bash -c 'lxc launch -qe ubuntu:jammy {[vars]lxd_name} -c=user.user-data="$(<{[vars]ftest_path}/test_setup.yaml)"'
+    # Wait for the cloud-init process to finish
+    lxc exec {[vars]lxd_name} -- bash -c "cloud-init status -w >/dev/null 2>&1"
+    # Copy all the files needed for integration testing
+    lxc file push -qp {toxinidir}/tox.ini {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qp {toxinidir}/pyproject.toml {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qp {toxinidir}/config.yaml {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qpr {toxinidir}/lib {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qpr {toxinidir}/src {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qpr {[vars]tst_path} {[vars]lxd_name}/{[vars]lxd_name}/
+    # Run the tests
+    lxc exec {[vars]lxd_name} -- tox -c /{[vars]lxd_name}/tox.ini -e functional-tests {posargs}
+commands_post =
+    -lxc stop {[vars]lxd_name}
+
+[testenv:functional-tests]
+description = Run functional tests
+deps =
+    ops==1.5.4
+    pytest==7.2.0
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --ignore={[vars]tst_path}unit \
+           --ignore={[vars]tst_path}integration \
+           --log-cli-level=INFO \
+           {posargs}
 
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest
-    juju
-    pytest-operator
-    -r{toxinidir}/requirements.txt
+    pytest==7.2.0
+    juju==3.0.4
+    pytest-operator==0.22.0
+    requests==2.28.1
+    tenacity==8.1.0
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v \
+           -s \
+           --tb native \
+           --ignore={[vars]tst_path}unit \
+           --ignore={[vars]tst_path}functional \
+           --log-cli-level=INFO
+           --model controller \
+           --keep-models \
+           {posargs}


### PR DESCRIPTION
Hey folks, this PR establishes the initial unit tests and CI pipeline for slurmrestd-operator.

### Summary of Change

- Add initial templates for bug reports, enhancement requests, and pull requests
- Add a basic CI pipeline using GitHub actions
              - Inclusive language check
              - Lint
                  - A separate PR will cover linting changes, currently linting has not been run yet. Those changes will stem from the results of running `tox -e lint`.
              - Unit tests
- Formatting
              - Changes to the source code in this PR stem from running `tox -e fmt`. These changes result from using `black` and `ruff`.
- Unit Tests
              - These tests only test the typical expected behavior of the charm. Integration and functional tests will follow in later PRs however those are not covered here. 

Please take a look and ensure these changes are satisfactory and raise any questions, comments, or concerns!