### PR TITLE
Remove the install dependencies step from integration-test CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,8 +63,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install dependencies
-        run: python3 -m pip install tox
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Create version file
+        run: git describe --tags --always --dirty > version
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.2.0
         id: channel


### PR DESCRIPTION
## Description

The `Install dependencies` step of the `integration-test` job in https://github.com/omnivector-solutions/slurmrestd-operator/blob/main/.github/workflows/ci.yaml#L66 only installs tox, which is also installed further by the `Setup operator environment` step (https://github.com/omnivector-solutions/slurmrestd-operator/blob/main/.github/workflows/ci.yaml#L68) (see the logs in https://github.com/omnivector-solutions/slurmrestd-operator/actions/runs/4130049841/jobs/7144948802).

## How was the code tested?

The code was tested inside the GitHub CI pipeline that has been set up for this repository. 


## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
