### PR TITLE
Add support for Ubuntu 22.04: part 1

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,8 +2,11 @@ type: charm
 bases:
   - build-on:
       - name: ubuntu
-        channel: "20.04"
+        channel: "22.04"
     run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [amd64]
       - name: ubuntu
         channel: "20.04"
         architectures: [amd64]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,29 +1,24 @@
 name: slurmrestd
-
 summary: |
-    Interface to Slurm via REST API.
+  Interface to Slurm via REST API.
+description: |
+  This charm provides slurmrestd, munged, and the bindings to other utilities
+  that make lifecycle operations a breeze.
 
+  slurmrestd is a REST API interface for SLURM.
+source: https://github.com/omnivector-solutions/slurmrestd-operator
+issues: https://github.com/omnivector-solutions/slurmrestd-operator/issues
 maintainers:
     - OmniVector Solutions <admin@omnivector.solutions>
-
-description: |
-    This charm provides slurmrestd, munged, and the bindings to other utilities
-    that make lifecycle operations a breeze.
-
-    slurmrestd is a REST API interface for SLURM.
-
-tags:
-    - hpc
-    - slurm
-
-series:
-    - focal
-    - centos7
-
-provides:
-  slurmrestd:
-    interface: slurmrestd
+    - Jason C. Nucciarone <jason.nucciarone@canonical.com>
+    - David Gomez <david.gomez@canonical.com>
 
 requires:
   fluentbit:
     interface: fluentbit
+provides:
+  slurmrestd:
+    interface: slurmrestd
+
+assumes:
+  - juju


### PR DESCRIPTION
## Description

Hey folks! This is part 1 of my work to upgrade the slurmrestd-operator to support Ubuntu 22.04 (Jammy Jellyfish) as a base. This pull request mostly just contains metadata updates so that Juju does not fail when deploying slurmrestd-operator to a 22.04 machine. Part 2 will contain the relevant integration test and CI pipeline updates. This pull request is mostly intended to make it so that I can pull "Jammified" SLURM charms from Charmhub for the integration tests.

Here are a couple of things that I changed in this pull request.

- Added me and David as maintainers in `metadata.yaml`. I felt that it would be good for us to be listed in maintainers so third-parties know who to contact about Canonical-licensed bits of code.
- Organized sections in `metadata.yaml`.
  - `tags` and `series` [are not supported options](https://juju.is/docs/sdk/metadata-yaml).  
- Added links for finding source code and issue tracker.
- Added assumes Juju so the charm is not accidentally deployed to a k8s charm.
- Added Ubuntu 22.04 to the `runs-on` section of `charmcraft.yaml`.

### Warning

Billy and I were investigating some issues with slurmrestd on Jammy. In the 21.08 release of SLURM, you can no longer use _SlurmUser_ or _root_ to start the slurmrestd daemon; slurmrestd will encounter a fatal error if you try to do so. Not sure if this something specific to my current tests, but once we get the integration tests up and running I should be able to get a better idea of what the problem is.

## How was the code tested?

I tested the code manually on my local machine due to Ubuntu 22.04 charms not being currently published to the edge channel on Charmhub.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
