### PR TITLE
Update slurm-ops-manager to version 0.8.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ops==1.3.0
-git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.7
+git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.12


### PR DESCRIPTION
## Description

Update `slurm-ops-manager` to version 0.8.12.

This will fix an issue with newer versions of slurmrestd which do not create the slurmrestd user.

## How was the code tested?

The code was tested locally on jammy deployed on LXD and also by the CI workflow.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.