### PR TITLE
Drop needs_reboot conditional in `_check_status(...)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+version

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,7 +5,6 @@
 """SlurmrestdCharm."""
 
 import logging
-import subprocess
 from pathlib import Path
 
 from charms.fluentbit.v0.fluentbit import FluentbitClient
@@ -13,7 +12,7 @@ from interface_slurmrestd import SlurmrestdRequires
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from slurm_ops_manager import SlurmManager
 
 logger = logging.getLogger()
@@ -135,15 +134,6 @@ class SlurmrestdCharm(CharmBase):
         self._slurm_manager.configure_jwt_rsa(jwt_rsa)
 
     def _check_status(self) -> bool:
-        if self._slurm_manager.needs_reboot:
-            try:
-                self.unit.status = MaintenanceStatus("Rebooting...")
-                logger.debug("Scheduling machine reboot")
-                subprocess.run(["juju-reboot"], check=True)
-            except subprocess.CalledProcessError:
-                logger.error("Failed to schedule machine reboot")
-            return False
-
         if not self._stored.slurm_installed:
             self.unit.status = BlockedStatus("Error installing slurmrestd")
             return False

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -40,10 +40,6 @@ class TestCharm(unittest.TestCase):
         return_value={"cluster_name": "test"},
     )
     @patch(
-        "slurm_ops_manager.SlurmManager.needs_reboot",
-        new_callable=PropertyMock(return_value=False),
-    )
-    @patch(
         "interface_slurmrestd.SlurmrestdRequires.is_joined",
         new_callable=PropertyMock(return_value=True),
     )
@@ -69,10 +65,6 @@ class TestCharm(unittest.TestCase):
         self.assertFalse(self.harness.charm._stored.slurm_installed)
         defer.assert_called()
 
-    @patch(
-        "slurm_ops_manager.SlurmManager.needs_reboot",
-        new_callable=PropertyMock(return_value=False),
-    )
     @patch(
         "interface_slurmrestd.SlurmrestdRequires.is_joined",
         new_callable=PropertyMock(return_value=True),
@@ -126,10 +118,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("slurm_ops_manager.SlurmManager.restart_slurm_component", lambda _: True)
     @patch(
-        "slurm_ops_manager.SlurmManager.needs_reboot",
-        new_callable=PropertyMock(return_value=False),
-    )
-    @patch(
         "interface_slurmrestd.SlurmrestdRequires.is_joined",
         new_callable=PropertyMock(return_value=True),
     )
@@ -155,10 +143,6 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch(
-        "slurm_ops_manager.SlurmManager.needs_reboot",
-        new_callable=PropertyMock(return_value=False),
-    )
-    @patch(
         "interface_slurmrestd.SlurmrestdRequires.is_joined",
         new_callable=PropertyMock(return_value=True),
     )
@@ -179,10 +163,6 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("pathlib.Path.read_text", return_value="v1.0.0")
-    @patch(
-        "slurm_ops_manager.SlurmManager.needs_reboot",
-        new_callable=PropertyMock(return_value=False),
-    )
     @patch(
         "interface_slurmrestd.SlurmrestdRequires.is_joined",
         new_callable=PropertyMock(return_value=True),


### PR DESCRIPTION
## Description

This pull request adds `juju-reboot` to the `_check_status(...)` function so that the machine will automatically restart if it needs security updates applied. Using `juju-reboot` helps with automatic deployments as a human-operator is not required to manually intervene when the slurmrestd charm is first deployed.

## How was the code tested?

I tested this charm on a private OpenStack instance with ubuntu@22.04 base images that needed security updates to be deployed.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
