### PR TITLE
Drop support for CentOS 7

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,9 +13,6 @@ bases:
       - name: ubuntu
         channel: "20.04"
         architectures: [amd64]
-      - name: centos
-        channel: "7"
-        architectures: [amd64]
 
 parts:
   charm:

--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,7 @@ options:
       This can be set to the Organization's local mirror/cache of packages and
       supersedes the Omnivector repositories. Alternatively, it can be used to
       track a `testing` Slurm version, e.g. by setting to
-      `ppa:omnivector/osd-testing` (on Ubuntu), or
-      `https://omnivector-solutions.github.io/repo/centos7/stable/$basearch`
-      (on CentOS).
+      `ppa:omnivector/osd-testing`.
 
       Note: The configuration `custom-slurm-repo` must be set *before*
       deploying the units. Changing this value after deploying the units will

--- a/dispatch
+++ b/dispatch
@@ -5,39 +5,4 @@
 
 set -e
 
-# Source the os-release information into the env.
-. /etc/os-release
-
-if ! [[ -f '.installed' ]]
-then
-	# Determine if we are running in centos or ubuntu, if centos
-	# provision the needed prereqs.
-	if [[ $ID == 'ubuntu' ]]
-	then
-		echo "Running Ubuntu."
-		echo "Nothing to do."
-	elif [[ $ID == 'centos' ]]
-	then
-		# Determine the centos version and install prereqs accordingly
-		major=$(cat /etc/centos-release | tr -dc '0-9.'|cut -d \. -f1)
-			echo "Running CentOS$major, installing prereqs."
-		if [[ $major == "7" ]]
-		then
-			yum -y install epel-release
-			yum -y install yum-priorities python3
-		elif [[ $major == "8" ]]
-		then
-			dnf -y install epel-release
-			dnf -y install yum-priorities python3
-		else
-			echo "Running unsuppored version of centos: $major"
-			exit -1
-		fi
-	else
-		echo "Running unsuppored os: $ID"
-		exit -1
-	fi
-	touch .installed
-fi
-
 JUJU_DISPATCH_PATH="${JUJU_DISPATCH_PATH:-$0}" PYTHONPATH=lib:venv ./src/charm.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ops==1.3.0
+ops==2.*
 git+https://github.com/omnivector-solutions/slurm-ops-manager.git@0.8.12


### PR DESCRIPTION
## Description

- Drop support for CentOS 7.
- Update `requirements.txt`, setting `ops==2.*`.

## How was the code tested?

The code was tested locally with LXD containers running Ubuntu 22.04.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [ ] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
